### PR TITLE
Add witness explorer UI

### DIFF
--- a/witnessWitness/README.md
+++ b/witnessWitness/README.md
@@ -1,3 +1,12 @@
 # Witness Witness
 
-This is a proof of concept for creating a tracker history of Congressional hearing witnesses. 
+This is a proof of concept for creating a tracker history of Congressional hearing witnesses.
+
+## Run the explorer locally
+
+1. From the repository root start a static server. Any option works; for example:
+   - Python: `python3 -m http.server 8000 --directory witnessWitness`
+   - uv: `uv run python -m http.server 8000 --directory witnessWitness`
+   - npm http-server: `npx http-server witnessWitness` (after `npm init -y` and `npm install --save-dev http-server`)
+2. Open your browser to `http://localhost:8000/` (or the port shown in the server output).
+3. Interact with `index.html` to explore witnesses, filter hearings, and follow hearing links.

--- a/witnessWitness/app.js
+++ b/witnessWitness/app.js
@@ -1,0 +1,654 @@
+const state = {
+  hearings: [],
+  witnessMap: new Map(),
+  sortedWitnesses: [],
+  filters: {
+    witnessQuery: '',
+    committee: 'all',
+    tag: 'all',
+    startDate: null,
+    endDate: null,
+  },
+  selectedWitnessKey: null,
+  filteredHearings: [],
+  dateRange: { min: null, max: null },
+};
+
+const elements = {
+  witnessSearch: document.getElementById('witnessSearch'),
+  committeeFilter: document.getElementById('committeeFilter'),
+  tagFilter: document.getElementById('tagFilter'),
+  startDate: document.getElementById('startDate'),
+  endDate: document.getElementById('endDate'),
+  clearFilters: document.getElementById('clearFilters'),
+  witnessList: document.getElementById('witnessList'),
+  hearingsTableBody: document.querySelector('#hearingsTable tbody'),
+  totalHearings: document.getElementById('totalHearings'),
+  uniqueWitnesses: document.getElementById('uniqueWitnesses'),
+  selectedWitnessCount: document.getElementById('selectedWitnessCount'),
+  detailsTitle: document.getElementById('detailsTitle'),
+  detailsSubtitle: document.getElementById('detailsSubtitle'),
+};
+
+document.addEventListener('DOMContentLoaded', initialise);
+
+async function initialise() {
+  showTableMessage('Loading hearings…');
+  attachEventListeners();
+
+  try {
+    const text = await fetchCSV('Senate Committee Hearings.csv');
+    const rows = parseCSV(text);
+
+    if (!rows.length) {
+      showTableMessage('No data rows were found in the CSV.');
+      return;
+    }
+
+    const [headerRow, ...dataRows] = rows;
+    const columns = headerRow.map((col) => col.trim());
+
+    const hearings = dataRows
+      .map((row) => rowToHearing(row, columns))
+      .filter(Boolean);
+
+    if (!hearings.length) {
+      showTableMessage('No hearings could be parsed from the CSV.');
+      return;
+    }
+
+    state.hearings = hearings;
+    elements.totalHearings.textContent = hearings.length.toLocaleString();
+
+    state.dateRange = computeDateRange(hearings);
+    applyDateBounds();
+
+    state.witnessMap = buildWitnessMap(hearings);
+    state.sortedWitnesses = Array.from(state.witnessMap.values()).sort(sortWitnesses);
+    elements.uniqueWitnesses.textContent = state.sortedWitnesses.length.toLocaleString();
+
+    populateFilterOptions();
+    renderWitnessList();
+    applyFilters();
+  } catch (error) {
+    console.error('Failed to load hearings CSV', error);
+    showTableMessage('Unable to load the CSV file. Ensure you are running a local server.');
+  }
+}
+
+function attachEventListeners() {
+  elements.witnessSearch.addEventListener('input', (event) => {
+    state.filters.witnessQuery = event.target.value.trim();
+    renderWitnessList();
+  });
+
+  elements.committeeFilter.addEventListener('change', (event) => {
+    state.filters.committee = event.target.value;
+    applyFilters();
+  });
+
+  elements.tagFilter.addEventListener('change', (event) => {
+    state.filters.tag = event.target.value;
+    applyFilters();
+  });
+
+  elements.startDate.addEventListener('change', (event) => {
+    state.filters.startDate = event.target.value ? new Date(event.target.value) : null;
+    applyFilters();
+  });
+
+  elements.endDate.addEventListener('change', (event) => {
+    state.filters.endDate = event.target.value ? new Date(event.target.value) : null;
+    applyFilters();
+  });
+
+  elements.clearFilters.addEventListener('click', () => {
+    state.filters = {
+      witnessQuery: '',
+      committee: 'all',
+      tag: 'all',
+      startDate: null,
+      endDate: null,
+    };
+    state.selectedWitnessKey = null;
+
+    elements.witnessSearch.value = '';
+    elements.committeeFilter.value = 'all';
+    elements.tagFilter.value = 'all';
+    elements.startDate.value = '';
+    elements.endDate.value = '';
+
+    renderWitnessList();
+    applyFilters();
+  });
+}
+
+async function fetchCSV(path) {
+  const response = await fetch(path, {
+    headers: { 'Cache-Control': 'no-cache' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} while fetching ${path}`);
+  }
+
+  return response.text();
+}
+
+function parseCSV(rawText) {
+  if (!rawText) return [];
+
+  let text = rawText;
+  if (text.charCodeAt(0) === 0xfeff) {
+    text = text.slice(1);
+  }
+
+  text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  const rows = [];
+  let currentCell = '';
+  let currentRow = [];
+  let withinQuotes = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const nextChar = text[index + 1];
+
+    if (char === '"') {
+      if (withinQuotes && nextChar === '"') {
+        currentCell += '"';
+        index += 1;
+      } else {
+        withinQuotes = !withinQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !withinQuotes) {
+      currentRow.push(currentCell);
+      currentCell = '';
+      continue;
+    }
+
+    if (char === '\n' && !withinQuotes) {
+      currentRow.push(currentCell);
+      rows.push(currentRow);
+      currentRow = [];
+      currentCell = '';
+      continue;
+    }
+
+    currentCell += char;
+  }
+
+  // Push the last cell if there's any residue.
+  if (currentCell.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentCell);
+    rows.push(currentRow);
+  }
+
+  return rows;
+}
+
+function rowToHearing(row, columns) {
+  if (!row || row.every((cell) => cell.trim() === '')) {
+    return null;
+  }
+
+  const record = {};
+  columns.forEach((column, index) => {
+    record[column] = row[index] || '';
+  });
+
+  const dateString = record.Date ? record.Date.trim() : '';
+  const parsedDate = parseDateString(dateString);
+
+  const witnesses = normalizeWitnesses(record.Witnesses || '');
+  const tags = Array.from(new Set(normalizeTags(record.Tags || '')));
+
+  return {
+    date: dateString,
+    dateObj: parsedDate,
+    title: (record.Title || '').trim(),
+    committee: (record.Committee || '').trim(),
+    pageUrl: (record.URL || '').trim(),
+    videoUrl: (record['Video Url'] || '').trim(),
+    tags,
+    witnesses,
+    witnessKeys: witnesses.map((name) => nameToKey(name)),
+  };
+}
+
+function parseDateString(value) {
+  if (!value) return null;
+  const parts = value.split('/');
+  if (parts.length < 3) return null;
+
+  const month = Number(parts[0]);
+  const day = Number(parts[1]);
+  let year = parts[2];
+
+  if (Number.isNaN(month) || Number.isNaN(day)) return null;
+
+  if (year.length === 2) {
+    const numeric = Number(year);
+    year = numeric >= 70 ? 1900 + numeric : 2000 + numeric;
+  } else {
+    year = Number(year);
+  }
+
+  if (!year || Number.isNaN(year)) return null;
+
+  return new Date(year, month - 1, day);
+}
+
+function normalizeWitnesses(raw) {
+  if (!raw) return [];
+
+  return raw
+    .replace(/\u2022|\u25cf|\*/g, '\n')
+    .replace(/\r/g, '')
+    .split(/\n+/)
+    .flatMap((entry) => entry.split(/\s*;\s*/))
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function normalizeTags(raw) {
+  if (!raw) return [];
+  const cleaned = raw.replace(/\r|\n/g, '').trim();
+  if (!cleaned) return [];
+
+  const candidate = cleaned.replace(/""/g, '"');
+
+  try {
+    const parsed = JSON.parse(candidate);
+    if (Array.isArray(parsed)) {
+      return parsed.map((tag) => String(tag).trim()).filter(Boolean);
+    }
+  } catch (error) {
+    // Fall back to manual parsing when JSON.parse fails.
+  }
+
+  const fallback = candidate
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .replace(/[\"]/g, '');
+
+  return fallback
+    .split(/,\s*/)
+    .map((tag) => tag.replace(/^'+|'+$/g, '').trim())
+    .filter(Boolean);
+}
+
+function buildWitnessMap(hearings) {
+  const map = new Map();
+
+  hearings.forEach((hearing) => {
+    const seenDuringHearing = new Set();
+
+    hearing.witnesses.forEach((name, index) => {
+      const key = hearing.witnessKeys[index];
+      if (!key || seenDuringHearing.has(key)) {
+        return;
+      }
+
+      seenDuringHearing.add(key);
+
+      const entry = map.get(key) || {
+        key,
+        name,
+        hearings: [],
+        count: 0,
+      };
+
+      if (!entry.name || entry.name.length < name.length) {
+        entry.name = name;
+      }
+
+      entry.hearings.push(hearing);
+      entry.count += 1;
+
+      map.set(key, entry);
+    });
+  });
+
+  return map;
+}
+
+function sortWitnesses(a, b) {
+  if (b.count !== a.count) {
+    return b.count - a.count;
+  }
+  return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+}
+
+function populateFilterOptions() {
+  const committees = Array.from(
+    new Set(state.hearings.map((hearing) => hearing.committee).filter(Boolean)),
+  ).sort((a, b) => a.localeCompare(b));
+
+  elements.committeeFilter.innerHTML = '';
+  elements.committeeFilter.append(new Option('All committees', 'all'));
+  committees.forEach((committee) => {
+    elements.committeeFilter.append(new Option(committee, committee));
+  });
+
+  const tags = Array.from(
+    new Set(
+      state.hearings.flatMap((hearing) => hearing.tags).map((tag) => tag.trim()).filter(Boolean),
+    ),
+  ).sort((a, b) => a.localeCompare(b));
+
+  elements.tagFilter.innerHTML = '';
+  elements.tagFilter.append(new Option('All tags', 'all'));
+  if (!tags.length) {
+    elements.tagFilter.disabled = true;
+  } else {
+    elements.tagFilter.disabled = false;
+    tags.forEach((tag) => {
+      elements.tagFilter.append(new Option(tag, tag));
+    });
+  }
+}
+
+function renderWitnessList() {
+  const container = elements.witnessList;
+  container.innerHTML = '';
+
+  if (!state.sortedWitnesses.length) {
+    container.textContent = 'No witnesses found.';
+    return;
+  }
+
+  const query = state.filters.witnessQuery.toLowerCase();
+  const matching = state.sortedWitnesses.filter((witness) =>
+    !query || witness.name.toLowerCase().includes(query),
+  );
+
+  if (!matching.length) {
+    container.textContent = 'No witnesses match that search.';
+    return;
+  }
+
+  matching.forEach((witness) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'witness-item';
+    if (state.selectedWitnessKey === witness.key) {
+      button.classList.add('active');
+    }
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'witness-item__name';
+    nameSpan.textContent = witness.name;
+
+    const countSpan = document.createElement('span');
+    countSpan.className = 'witness-item__count';
+    countSpan.textContent = `${witness.count.toLocaleString()} hearings`;
+
+    button.append(nameSpan, countSpan);
+
+    button.addEventListener('click', () => {
+      state.selectedWitnessKey = state.selectedWitnessKey === witness.key ? null : witness.key;
+      renderWitnessList();
+      applyFilters();
+      scrollToTable();
+    });
+
+    container.append(button);
+  });
+}
+
+function applyFilters() {
+  const { hearings, filters, selectedWitnessKey } = state;
+
+  let filtered = hearings.filter((hearing) => {
+    if (filters.committee !== 'all' && hearing.committee !== filters.committee) {
+      return false;
+    }
+
+    if (filters.tag !== 'all' && !hearing.tags.includes(filters.tag)) {
+      return false;
+    }
+
+    if (filters.startDate && hearing.dateObj && hearing.dateObj < filters.startDate) {
+      return false;
+    }
+
+    if (filters.endDate && hearing.dateObj && hearing.dateObj > filters.endDate) {
+      return false;
+    }
+
+    return true;
+  });
+
+  if (selectedWitnessKey) {
+    filtered = filtered.filter((hearing) => hearing.witnessKeys.includes(selectedWitnessKey));
+  }
+
+  state.filteredHearings = filtered;
+  renderHearingsTable(filtered);
+  updateSummary(filtered);
+}
+
+function renderHearingsTable(hearings) {
+  const tbody = elements.hearingsTableBody;
+  tbody.innerHTML = '';
+
+  if (!hearings.length) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 5;
+    cell.className = 'empty-state';
+    cell.textContent = 'No hearings match the current filters.';
+    row.append(cell);
+    tbody.append(row);
+    return;
+  }
+
+  hearings.forEach((hearing) => {
+    const row = document.createElement('tr');
+
+    const dateCell = document.createElement('td');
+    dateCell.textContent = hearing.dateObj ? formatDate(hearing.dateObj) : hearing.date;
+    row.append(dateCell);
+
+    const titleCell = document.createElement('td');
+    const titleLink = document.createElement('a');
+    titleLink.className = 'hearing-title';
+    titleLink.textContent = hearing.title || 'Untitled hearing';
+    if (hearing.pageUrl) {
+      titleLink.href = hearing.pageUrl;
+      titleLink.target = '_blank';
+      titleLink.rel = 'noopener noreferrer';
+    } else {
+      titleLink.href = '#';
+      titleLink.addEventListener('click', (event) => event.preventDefault());
+    }
+
+    titleCell.append(titleLink);
+
+    if (hearing.pageUrl || hearing.videoUrl) {
+      const linkRow = document.createElement('div');
+      linkRow.className = 'hearing-links';
+      if (hearing.pageUrl) {
+        const pageAnchor = document.createElement('a');
+        pageAnchor.href = hearing.pageUrl;
+        pageAnchor.target = '_blank';
+        pageAnchor.rel = 'noopener noreferrer';
+        pageAnchor.textContent = 'Hearing page';
+        linkRow.append(pageAnchor);
+      }
+      if (hearing.videoUrl) {
+        const videoAnchor = document.createElement('a');
+        videoAnchor.href = hearing.videoUrl;
+        videoAnchor.target = '_blank';
+        videoAnchor.rel = 'noopener noreferrer';
+        videoAnchor.textContent = 'Watch video';
+        linkRow.append(videoAnchor);
+      }
+      titleCell.append(linkRow);
+    }
+
+    row.append(titleCell);
+
+    const committeeCell = document.createElement('td');
+    committeeCell.textContent = hearing.committee || '—';
+    row.append(committeeCell);
+
+    const witnessesCell = document.createElement('td');
+    if (!hearing.witnesses.length) {
+      witnessesCell.textContent = '—';
+    } else {
+      hearing.witnesses.forEach((name) => {
+        const chip = document.createElement('span');
+        chip.className = 'witness-chip';
+        chip.textContent = name;
+        if (state.selectedWitnessKey && nameToKey(name) === state.selectedWitnessKey) {
+          chip.classList.add('witness-chip--active');
+        }
+        witnessesCell.append(chip);
+      });
+    }
+    row.append(witnessesCell);
+
+    const tagsCell = document.createElement('td');
+    if (!hearing.tags.length) {
+      tagsCell.textContent = '—';
+    } else {
+      hearing.tags.forEach((tag) => {
+        const pill = document.createElement('span');
+        pill.className = 'tag-pill';
+        pill.textContent = tag;
+        tagsCell.append(pill);
+      });
+    }
+    row.append(tagsCell);
+
+    tbody.append(row);
+  });
+}
+
+function updateSummary(filteredHearings) {
+  const selectedEntry = state.selectedWitnessKey
+    ? state.witnessMap.get(state.selectedWitnessKey)
+    : null;
+
+  const baseCount = selectedEntry ? selectedEntry.count : 0;
+  const filteredCount = selectedEntry ? filteredHearings.length : 0;
+
+  elements.selectedWitnessCount.textContent = filteredCount.toLocaleString();
+
+  if (selectedEntry) {
+    elements.detailsTitle.textContent = `${selectedEntry.name} hearings`;
+    if (filteredCount === baseCount) {
+      elements.detailsSubtitle.textContent = `Showing all ${filteredCount.toLocaleString()} hearings for ${selectedEntry.name}.`;
+    } else {
+      elements.detailsSubtitle.textContent = `Showing ${filteredCount.toLocaleString()} of ${baseCount.toLocaleString()} hearings for ${selectedEntry.name} after filters.`;
+    }
+  } else {
+    elements.detailsTitle.textContent = 'All hearings';
+    const filterSummary = describeFilters();
+    elements.detailsSubtitle.textContent = `Showing ${filteredHearings.length.toLocaleString()} hearings${filterSummary}.`;
+    elements.selectedWitnessCount.textContent = '0';
+  }
+}
+
+function describeFilters() {
+  const { committee, tag, startDate, endDate } = state.filters;
+  const parts = [];
+
+  if (committee !== 'all') {
+    parts.push(`committee: ${committee}`);
+  }
+
+  if (tag !== 'all') {
+    parts.push(`tag: ${tag}`);
+  }
+
+  if (startDate) {
+    parts.push(`from ${formatDate(startDate)}`);
+  }
+
+  if (endDate) {
+    parts.push(`through ${formatDate(endDate)}`);
+  }
+
+  if (!parts.length) {
+    return '.';
+  }
+
+  return ` with ${parts.join(', ')}.`;
+}
+
+function nameToKey(name) {
+  return name ? name.toLowerCase().replace(/\s+/g, ' ').trim() : '';
+}
+
+function formatDate(date) {
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function computeDateRange(hearings) {
+  const dates = hearings
+    .map((hearing) => hearing.dateObj)
+    .filter((date) => date instanceof Date && !Number.isNaN(date.getTime()));
+
+  if (!dates.length) {
+    return { min: null, max: null };
+  }
+
+  let min = dates[0];
+  let max = dates[0];
+
+  dates.forEach((date) => {
+    if (date < min) min = date;
+    if (date > max) max = date;
+  });
+
+  return { min, max };
+}
+
+function applyDateBounds() {
+  const { min, max } = state.dateRange;
+  if (!min || !max) return;
+
+  const minIso = dateToInputValue(min);
+  const maxIso = dateToInputValue(max);
+
+  elements.startDate.min = minIso;
+  elements.startDate.max = maxIso;
+  elements.endDate.min = minIso;
+  elements.endDate.max = maxIso;
+}
+
+function dateToInputValue(date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function showTableMessage(message) {
+  const tbody = elements.hearingsTableBody;
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  const row = document.createElement('tr');
+  const cell = document.createElement('td');
+  cell.colSpan = 5;
+  cell.className = 'empty-state';
+  cell.textContent = message;
+  row.append(cell);
+  tbody.append(row);
+}
+
+function scrollToTable() {
+  const table = document.getElementById('hearingsTable');
+  if (!table) return;
+  table.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}

--- a/witnessWitness/index.html
+++ b/witnessWitness/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Witness Witness Explorer</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="page-header">
+    <h1>Witness Witness Explorer</h1>
+    <p>Filter Senate committee hearings and spotlight the witnesses who appear.</p>
+  </header>
+  <main class="layout">
+    <aside class="sidebar">
+      <section class="panel">
+        <h2>Filters</h2>
+        <div class="form-group">
+          <label for="witnessSearch">Search witnesses</label>
+          <input id="witnessSearch" type="search" placeholder="Type a name…">
+        </div>
+        <div class="form-group">
+          <label for="committeeFilter">Committee</label>
+          <select id="committeeFilter"></select>
+        </div>
+        <div class="form-group">
+          <label for="tagFilter">Tag</label>
+          <select id="tagFilter"></select>
+        </div>
+        <div class="form-group form-group--dates">
+          <label>Date range</label>
+          <div class="date-inputs">
+            <input id="startDate" type="date">
+            <input id="endDate" type="date">
+          </div>
+        </div>
+        <button id="clearFilters" class="button button--secondary" type="button">Clear filters</button>
+      </section>
+      <section class="panel">
+        <h2>Witnesses</h2>
+        <div id="witnessList" class="witness-list" aria-live="polite"></div>
+      </section>
+    </aside>
+    <section class="content">
+      <section class="summary" aria-live="polite">
+        <div class="stat-card">
+          <div class="stat-label">Hearings loaded</div>
+          <div id="totalHearings" class="stat-value">0</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Unique witnesses</div>
+          <div id="uniqueWitnesses" class="stat-value">0</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Selected witness hearings</div>
+          <div id="selectedWitnessCount" class="stat-value">0</div>
+        </div>
+      </section>
+      <section class="details">
+        <header class="details__header">
+          <h2 id="detailsTitle">All hearings</h2>
+          <p id="detailsSubtitle">Choose a witness to drill into their hearing history.</p>
+        </header>
+        <div class="table-wrapper">
+          <table id="hearingsTable">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Title</th>
+                <th>Committee</th>
+                <th>Witnesses</th>
+                <th>Tags</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </section>
+  </main>
+  <footer class="page-footer">
+    <p>Tip: open this folder with a simple web server (<code>python -m http.server</code>) so the CSV can be fetched locally.</p>
+  </footer>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/witnessWitness/styles.css
+++ b/witnessWitness/styles.css
@@ -1,0 +1,345 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  background-color: #f5f6f8;
+  color: #101828;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header {
+  background: linear-gradient(135deg, #212d63, #2c4aa0);
+  color: white;
+  padding: 1.75rem clamp(1rem, 3vw, 2.5rem);
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.page-header p {
+  margin: 0;
+  max-width: 60ch;
+  font-size: 1rem;
+  opacity: 0.9;
+}
+
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 2vw, 2.5rem);
+  align-items: start;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: white;
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.panel h2 {
+  font-size: 1.1rem;
+  margin: 0 0 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.form-group input,
+.form-group select {
+  padding: 0.55rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid #d0d5dd;
+  font-size: 0.95rem;
+  background: #f9fafb;
+  color: inherit;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+  outline: 2px solid #2c4aa0;
+  outline-offset: 2px;
+}
+
+.form-group--dates .date-inputs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.55rem 1.25rem;
+  cursor: pointer;
+  border: none;
+}
+
+.button--secondary {
+  background: rgba(33, 45, 99, 0.08);
+  color: #212d63;
+}
+
+.button--secondary:hover {
+  background: rgba(33, 45, 99, 0.14);
+}
+
+.witness-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.witness-item {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 10px;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+  cursor: pointer;
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.witness-item:hover {
+  border-color: rgba(44, 74, 160, 0.4);
+  box-shadow: 0 10px 20px rgba(44, 74, 160, 0.12);
+  transform: translateY(-1px);
+}
+
+.witness-item.active {
+  border-color: rgba(44, 74, 160, 0.6);
+  background: rgba(44, 74, 160, 0.1);
+}
+
+.witness-item__name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.witness-item__count {
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  color: #475467;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  background: white;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.05);
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: #475467;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.45rem;
+}
+
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.details {
+  background: white;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.details__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.details__header p {
+  margin: 0.3rem 0 0;
+  color: #475467;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+thead {
+  background: rgba(33, 45, 99, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+thead th {
+  text-align: left;
+  padding: 0.75rem 0.85rem;
+  font-weight: 600;
+  color: #182656;
+}
+
+tbody td {
+  padding: 0.7rem 0.85rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  vertical-align: top;
+}
+
+tbody tr:hover {
+  background: rgba(33, 45, 99, 0.06);
+}
+
+.hearing-title {
+  font-weight: 600;
+  color: #15224b;
+  margin-bottom: 0.15rem;
+}
+
+.hearing-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
+}
+
+.hearing-links a {
+  color: #2c4aa0;
+  text-decoration: none;
+  font-size: 0.85rem;
+  border-bottom: 1px solid transparent;
+}
+
+.hearing-links a:hover {
+  border-bottom-color: currentColor;
+}
+
+.tag-pill {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(44, 74, 160, 0.12);
+  color: #2c4aa0;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+  font-size: 0.75rem;
+  margin-right: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.page-footer {
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.85rem;
+  color: #475467;
+}
+
+code {
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.15rem 0.3rem;
+  border-radius: 6px;
+}
+
+@media (max-width: 1024px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .witness-list {
+    max-height: 280px;
+  }
+}
+
+@media (max-width: 640px) {
+  .panel,
+  .details {
+    padding: 1.1rem;
+  }
+
+  thead th,
+  tbody td {
+    padding-inline: 0.6rem;
+  }
+}
+
+.empty-state {
+  text-align: center;
+  color: #475467;
+  padding: 1.5rem 0.85rem;
+}
+
+.witness-chip {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(33, 45, 99, 0.1);
+  color: #212d63;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+  font-size: 0.8rem;
+  margin: 0 0.3rem 0.3rem 0;
+  font-weight: 500;
+}
+
+.witness-chip--active {
+  background: #2c4aa0;
+  color: white;
+}


### PR DESCRIPTION
## Summary
- add a witness-focused explorer page and script under witnessWitness/
- build responsive styling for filters, witness list, and hearing table
- load the hearing CSV in-browser and support witness/committee/tag/date filters

## Testing
- not run (static assets)