### PR TITLE
Add sortable hearings table

### DIFF
--- a/witnessWitness/index.html
+++ b/witnessWitness/index.html
@@ -65,11 +65,36 @@
           <table id="hearingsTable">
             <thead>
               <tr>
-                <th>Date</th>
-                <th>Title</th>
-                <th>Committee</th>
-                <th>Witnesses</th>
-                <th>Tags</th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="date">
+                    Date
+                    <span class="sort-indicator" aria-hidden="true"></span>
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="title">
+                    Title
+                    <span class="sort-indicator" aria-hidden="true"></span>
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="committee">
+                    Committee
+                    <span class="sort-indicator" aria-hidden="true"></span>
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="witnesses">
+                    Witnesses
+                    <span class="sort-indicator" aria-hidden="true"></span>
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="tags">
+                    Tags
+                    <span class="sort-indicator" aria-hidden="true"></span>
+                  </button>
+                </th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/witnessWitness/styles.css
+++ b/witnessWitness/styles.css
@@ -235,7 +235,7 @@ thead {
 
 thead th {
   text-align: left;
-  padding: 0.75rem 0.85rem;
+  padding: 0;
   font-weight: 600;
   color: #182656;
 }
@@ -244,6 +244,50 @@ tbody td {
   padding: 0.7rem 0.85rem;
   border-bottom: 1px solid rgba(15, 23, 42, 0.08);
   vertical-align: top;
+}
+
+.sort-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.35rem;
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  font-weight: inherit;
+  text-align: left;
+  padding: 0.75rem 0.85rem;
+  cursor: pointer;
+}
+
+.sort-button:hover {
+  background: rgba(44, 74, 160, 0.08);
+}
+
+.sort-button:focus-visible {
+  outline: 2px solid #2c4aa0;
+  outline-offset: -2px;
+  border-radius: 6px;
+}
+
+.sort-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.85rem;
+  height: 0.85rem;
+  font-size: 0.75rem;
+  color: #475467;
+}
+
+.sort-button[data-sort-direction="asc"] .sort-indicator::before {
+  content: '▲';
+}
+
+.sort-button[data-sort-direction="desc"] .sort-indicator::before {
+  content: '▼';
 }
 
 tbody tr:hover {


### PR DESCRIPTION
## Summary
- make hearings table headers clickable sort controls with direction indicators
- persist sort state in the UI and apply column-aware comparisons
- keep accessibility metadata in sync while preserving witness filtering

## Testing
- node --check witnessWitness/app.js