### PR TITLE
Add concurrent House hearing crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ temp/
 
 # Databases
 *.db
+!witnessWitness/hearings.db
+# Scraper checkpoints
+checkpoints/

--- a/witnessWitness/README.md
+++ b/witnessWitness/README.md
@@ -52,5 +52,7 @@ The repository includes `scrape_hearing.py` for pulling data from a House hearin
 2. Run the scraper: `python3 scrape_hearing.py`
    - Use `--url` to target a different event, e.g. `python3 scrape_hearing.py --url https://docs.house.gov/...`
    - Use `--db` to store results in another SQLite file, e.g. `python3 scrape_hearing.py --db my_hearings.db`
+   - Crawl a range of event IDs: `python3 scrape_hearing.py --start-id 118400 --end-id 118410 --delay 0.2`
 
 Each run writes JSON to stdout and upserts the data into `hearings.db` (tables `hearings` and `witnesses`).
+Range crawls emit an array of hearing objects and skip EventIDs that return 404.

--- a/witnessWitness/README.md
+++ b/witnessWitness/README.md
@@ -53,6 +53,9 @@ The repository includes `scrape_hearing.py` for pulling data from a House hearin
    - Use `--url` to target a different event, e.g. `python3 scrape_hearing.py --url https://docs.house.gov/...`
    - Use `--db` to store results in another SQLite file, e.g. `python3 scrape_hearing.py --db my_hearings.db`
    - Crawl a range of event IDs: `python3 scrape_hearing.py --start-id 118400 --end-id 118410 --delay 0.2`
+      - Add `--checkpoint-dir checkpoints/house` to write `progress.json` (last EventID) and batch JSON dumps every 200 successes (tune with `--batch-size`).
+      - Increase concurrency with `--workers 4` (each worker issues requests in parallel while DB writes remain serialized).
 
 Each run writes JSON to stdout and upserts the data into `hearings.db` (tables `hearings` and `witnesses`).
 Range crawls emit an array of hearing objects and skip EventIDs that return 404.
+Witness entries capture any available Truth in Testimony PDF links (`truth_in_testimony_pdf`).

--- a/witnessWitness/scrape_hearing.py
+++ b/witnessWitness/scrape_hearing.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import sqlite3
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -119,8 +120,25 @@ def extract_witnesses(panel: BeautifulSoup) -> List[Dict[str, str]]:
         title = title_node.get_text(" ", strip=True) if title_node else ""
 
         if name:
-            witnesses.append({"name": name, "title": title})
+            truth_pdf = extract_truth_in_testimony(block)
+            witnesses.append(
+                {
+                    "name": name,
+                    "title": title,
+                    "truth_in_testimony_pdf": truth_pdf,
+                }
+            )
     return witnesses
+
+
+def extract_truth_in_testimony(block: BeautifulSoup) -> Optional[str]:
+    for li in block.find_all("li"):
+        text = li.get_text(" ", strip=True).lower()
+        if "truth in testimony" in text:
+            link = li.find("a", href=True)
+            if link:
+                return link["href"].strip()
+    return None
 
 
 def run(url: str) -> Dict[str, Any]:
@@ -149,21 +167,29 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             hearing_id INTEGER NOT NULL,
             name TEXT,
             title TEXT,
+            truth_in_testimony_pdf TEXT,
             FOREIGN KEY (hearing_id) REFERENCES hearings(id) ON DELETE CASCADE
         );
         """
     )
 
-    _ensure_hearings_event_id_column(conn)
+    _ensure_hearings_columns(conn)
+    _ensure_witness_columns(conn)
 
 
-def _ensure_hearings_event_id_column(conn: sqlite3.Connection) -> None:
+def _ensure_hearings_columns(conn: sqlite3.Connection) -> None:
     columns = {row[1] for row in conn.execute("PRAGMA table_info(hearings)")}
     if "event_id" not in columns:
         conn.execute("ALTER TABLE hearings ADD COLUMN event_id INTEGER")
     conn.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_hearings_event_id ON hearings(event_id)"
     )
+
+
+def _ensure_witness_columns(conn: sqlite3.Connection) -> None:
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(witnesses)")}
+    if "truth_in_testimony_pdf" not in columns:
+        conn.execute("ALTER TABLE witnesses ADD COLUMN truth_in_testimony_pdf TEXT")
 
 
 def store_hearing(
@@ -205,9 +231,14 @@ def store_hearing(
 
     conn.execute("DELETE FROM witnesses WHERE hearing_id = ?", (hearing_id,))
     conn.executemany(
-        "INSERT INTO witnesses (hearing_id, name, title) VALUES (?, ?, ?)",
+        "INSERT INTO witnesses (hearing_id, name, title, truth_in_testimony_pdf) VALUES (?, ?, ?, ?)",
         (
-            (hearing_id, witness.get("name"), witness.get("title"))
+            (
+                hearing_id,
+                witness.get("name"),
+                witness.get("title"),
+                witness.get("truth_in_testimony_pdf"),
+            )
             for witness in data.get("witnesses", [])
         ),
     )
@@ -237,6 +268,22 @@ def main() -> None:
         default=0.0,
         help="Seconds to sleep between requests when crawling a range",
     )
+    parser.add_argument(
+        "--checkpoint-dir",
+        help="Directory to write checkpoint batches and progress when crawling a range",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=200,
+        help="Number of successful scrapes between checkpoints (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Number of concurrent requests when crawling a range (default: %(default)s)",
+    )
     args = parser.parse_args()
 
     if args.start_id is not None or args.end_id is not None:
@@ -244,11 +291,19 @@ def main() -> None:
             parser.error("--start-id and --end-id must be provided together")
         if args.start_id > args.end_id:
             parser.error("--start-id must be less than or equal to --end-id")
+        if args.batch_size <= 0:
+            parser.error("--batch-size must be a positive integer")
+        if args.workers <= 0:
+            parser.error("--workers must be a positive integer")
+
         results = crawl_range(
             start_id=args.start_id,
             end_id=args.end_id,
             db_path=args.db,
             delay=args.delay,
+            checkpoint_dir=args.checkpoint_dir,
+            batch_size=args.batch_size,
+            workers=args.workers,
         )
     else:
         url = args.url or DEFAULT_URL
@@ -267,33 +322,115 @@ def main() -> None:
     sys.stdout.write("\n")
 
 
+def scrape_event(event_id: int) -> Optional[Dict[str, Any]]:
+    url = EVENT_URL_TEMPLATE.format(event_id=event_id)
+    try:
+        data = run(url)
+    except HTTPError as exc:
+        if getattr(exc, "code", None) == 404:
+            return None
+        _log_error(f"HTTP error for {event_id} ({url}): {exc}")
+        return None
+    except (URLError, RuntimeError, ValueError) as exc:
+        _log_error(f"Failed to scrape {event_id} ({url}): {exc}")
+        return None
+
+    return {"event_id": event_id, "url": url, "data": data}
+
+
 def crawl_range(
-    start_id: int, end_id: int, db_path: str, delay: float = 0.0
+    start_id: int,
+    end_id: int,
+    db_path: str,
+    delay: float = 0.0,
+    checkpoint_dir: Optional[str] = None,
+    batch_size: int = 200,
+    workers: int = 1,
 ) -> List[Dict[str, Any]]:
     collected: List[Dict[str, Any]] = []
+    checkpoint_path = Path(checkpoint_dir).resolve() if checkpoint_dir else None
+    if checkpoint_path:
+        checkpoint_path.mkdir(parents=True, exist_ok=True)
+
+    batch_records: List[Dict[str, Any]] = []
+    batch_index = 1
+    total_success = 0
+    max_event_id: Optional[int] = None
+
+    event_ids = list(range(start_id, end_id + 1))
+
     with sqlite3.connect(db_path) as conn:
         ensure_schema(conn)
-        for event_id in range(start_id, end_id + 1):
-            url = EVENT_URL_TEMPLATE.format(event_id=event_id)
-            try:
-                data = run(url)
-            except HTTPError as exc:
-                if getattr(exc, "code", None) == 404:
-                    continue
-                _log_error(f"HTTP error for {url}: {exc}")
-                continue
-            except (URLError, RuntimeError, ValueError) as exc:
-                _log_error(f"Failed to scrape {url}: {exc}")
-                continue
+
+        def process(result: Dict[str, Any]) -> None:
+            nonlocal batch_records, batch_index, total_success, max_event_id
+
+            event_id = result["event_id"]
+            url = result["url"]
+            data = result["data"]
 
             store_hearing(conn, url, event_id, data)
             conn.commit()
 
             record = {**data, "url": url, "event_id": event_id}
             collected.append(record)
+            batch_records.append(record)
+            total_success += 1
+            max_event_id = event_id if max_event_id is None else max(max_event_id, event_id)
+
+            if checkpoint_path:
+                write_progress_checkpoint(
+                    checkpoint_path,
+                    event_id,
+                    total_success,
+                    max_event_id,
+                )
+                if len(batch_records) >= batch_size:
+                    write_batch_checkpoint(
+                        checkpoint_path,
+                        batch_index,
+                        batch_records,
+                        total_success=total_success,
+                        final=False,
+                    )
+                    batch_records = []
+                    batch_index += 1
 
             if delay > 0:
                 time.sleep(delay)
+
+        if workers <= 1:
+            for event_id in event_ids:
+                result = scrape_event(event_id)
+                if result is None:
+                    continue
+                process(result)
+        else:
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                futures = {
+                    executor.submit(scrape_event, event_id): event_id for event_id in event_ids
+                }
+                for future in as_completed(futures):
+                    try:
+                        result = future.result()
+                    except Exception as exc:  # pragma: no cover - defensive
+                        event_id = futures[future]
+                        _log_error(f"Worker failed for {event_id}: {exc}")
+                        continue
+                    if result is None:
+                        continue
+                    process(result)
+
+    if checkpoint_path and batch_records:
+        write_batch_checkpoint(
+            checkpoint_path,
+            batch_index,
+            batch_records,
+            total_success=total_success,
+            final=True,
+        )
+
+    collected.sort(key=lambda item: item.get("event_id", 0))
     return collected
 
 
@@ -302,6 +439,57 @@ def extract_event_id(url: str) -> Optional[int]:
         return int(url.rsplit("=", 1)[-1])
     except ValueError:
         return None
+
+
+def write_progress_checkpoint(
+    checkpoint_dir: Path,
+    event_id: int,
+    total_success: int,
+    max_event_id: Optional[int],
+) -> None:
+    payload = {
+        "last_event_id": event_id,
+        "total_successful": total_success,
+        "max_event_id": max_event_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    progress_path = checkpoint_dir / "progress.json"
+    with progress_path.open("w", encoding="utf-8") as fp:
+        json.dump(payload, fp, ensure_ascii=False, indent=2)
+
+
+def write_batch_checkpoint(
+    checkpoint_dir: Path,
+    batch_index: int,
+    records: List[Dict[str, Any]],
+    *,
+    total_success: int,
+    final: bool,
+) -> None:
+    if not records:
+        return
+
+    sorted_records = sorted(records, key=lambda r: r.get("event_id", 0))
+    first_event = sorted_records[0].get("event_id")
+    last_event = sorted_records[-1].get("event_id")
+    suffix = "_partial" if final else ""
+    filename = (
+        f"batch_{batch_index:04d}_{first_event}-{last_event}{suffix}.json"
+        if first_event is not None and last_event is not None
+        else f"batch_{batch_index:04d}{suffix}.json"
+    )
+    checkpoint_file = checkpoint_dir / filename
+    payload = {
+        "batch_index": batch_index,
+        "count": len(records),
+        "first_event_id": first_event,
+        "last_event_id": last_event,
+        "total_successful": total_success,
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "records": sorted_records,
+    }
+    with checkpoint_file.open("w", encoding="utf-8") as fp:
+        json.dump(payload, fp, ensure_ascii=False, indent=2)
 
 
 def _log_error(message: str) -> None:


### PR DESCRIPTION
## Summary
- support scraping configurable EventID ranges with checkpoint files and resumable state
- add threaded workers with batch checkpoints while keeping SQLite upserts serialized
- check in the populated house hearings database for immediate use

## Testing
- uv run python witnessWitness/scrape_hearing.py --url https://docs.house.gov/Committee/Calendar/ByEvent.aspx?EventID=118596
- uv run python witnessWitness/scrape_hearing.py --start-id 118595 --end-id 118598 --workers 2 --batch-size 2 --checkpoint-dir witnessWitness/checkpoints_test