### PR TITLE
Merge hearings databases and update explorer

### DIFF
--- a/witnessWitness/app.js
+++ b/witnessWitness/app.js
@@ -1,3 +1,7 @@
+const COMBINED_DB_PATH = 'hearings_combined.db';
+const SQL_JS_CDN_BASE = 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/';
+let sqlJsInstancePromise;
+
 const state = {
   hearings: [],
   witnessMap: new Map(),
@@ -8,6 +12,7 @@ const state = {
     tag: 'all',
     startDate: null,
     endDate: null,
+    dualChamberOnly: false,
   },
   selectedWitnessKey: null,
   filteredHearings: [],
@@ -25,6 +30,7 @@ const elements = {
   startDate: document.getElementById('startDate'),
   endDate: document.getElementById('endDate'),
   clearFilters: document.getElementById('clearFilters'),
+  dualChamberToggle: null,
   witnessList: document.getElementById('witnessList'),
   hearingsTableBody: document.querySelector('#hearingsTable tbody'),
   totalHearings: document.getElementById('totalHearings'),
@@ -39,26 +45,19 @@ document.addEventListener('DOMContentLoaded', initialise);
 
 async function initialise() {
   showTableMessage('Loading hearings…');
+  ensureDualChamberButton();
   attachEventListeners();
 
   try {
-    const text = await fetchCSV('Senate Committee Hearings.csv');
-    const rows = parseCSV(text);
+    const SQL = await loadSqlJsInstance();
+    const databaseBytes = await fetchDatabase(COMBINED_DB_PATH);
+    const db = new SQL.Database(databaseBytes);
 
-    if (!rows.length) {
-      showTableMessage('No data rows were found in the CSV.');
-      return;
-    }
-
-    const [headerRow, ...dataRows] = rows;
-    const columns = headerRow.map((col) => col.trim());
-
-    const hearings = dataRows
-      .map((row) => rowToHearing(row, columns))
-      .filter(Boolean);
+    const hearings = buildHearingsFromDatabase(db);
+    db.close();
 
     if (!hearings.length) {
-      showTableMessage('No hearings could be parsed from the CSV.');
+      showTableMessage('No hearings could be loaded from the database.');
       return;
     }
 
@@ -76,8 +75,8 @@ async function initialise() {
     renderWitnessList();
     applyFilters();
   } catch (error) {
-    console.error('Failed to load hearings CSV', error);
-    showTableMessage('Unable to load the CSV file. Ensure you are running a local server.');
+    console.error('Failed to load hearings database', error);
+    showTableMessage('Unable to load the combined hearings database. Ensure you are running a local server.');
   }
 }
 
@@ -114,6 +113,7 @@ function attachEventListeners() {
       tag: 'all',
       startDate: null,
       endDate: null,
+      dualChamberOnly: false,
     };
     state.selectedWitnessKey = null;
 
@@ -123,6 +123,7 @@ function attachEventListeners() {
     elements.startDate.value = '';
     elements.endDate.value = '';
 
+    updateDualChamberButton();
     renderWitnessList();
     applyFilters();
   });
@@ -134,164 +135,222 @@ function attachEventListeners() {
       updateSort(sortKey);
     });
   });
+
+  if (elements.dualChamberToggle) {
+    elements.dualChamberToggle.addEventListener('click', () => {
+      state.filters.dualChamberOnly = !state.filters.dualChamberOnly;
+      if (state.filters.dualChamberOnly && state.selectedWitnessKey) {
+        const selected = state.witnessMap.get(state.selectedWitnessKey);
+        if (!selected || selected.chambers.size < 2) {
+          state.selectedWitnessKey = null;
+        }
+      }
+      updateDualChamberButton();
+      renderWitnessList();
+      applyFilters();
+    });
+  }
 }
 
-async function fetchCSV(path) {
-  const response = await fetch(path, {
-    headers: { 'Cache-Control': 'no-cache' },
+function ensureDualChamberButton() {
+  if (elements.dualChamberToggle) return;
+  if (!elements.clearFilters) return;
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.id = 'dualChamberToggle';
+  button.className = 'button button--secondary';
+  elements.clearFilters.insertAdjacentElement('afterend', button);
+
+  elements.dualChamberToggle = button;
+  updateDualChamberButton();
+}
+
+function updateDualChamberButton() {
+  if (!elements.dualChamberToggle) return;
+  const active = state.filters.dualChamberOnly;
+  elements.dualChamberToggle.textContent = active
+    ? 'Show all witnesses'
+    : 'Show dual-chamber witnesses';
+  elements.dualChamberToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
+}
+
+// Lazy-load sql.js from CDN and return the initialised module.
+function loadSqlJsInstance() {
+  if (sqlJsInstancePromise) {
+    return sqlJsInstancePromise;
+  }
+
+  sqlJsInstancePromise = new Promise((resolve, reject) => {
+    function initialise() {
+      if (typeof window.initSqlJs !== 'function') {
+        reject(new Error('sql.js init function not available.'));
+        return;
+      }
+      window
+        .initSqlJs({ locateFile: (file) => `${SQL_JS_CDN_BASE}${file}` })
+        .then(resolve)
+        .catch(reject);
+    }
+
+    if (typeof window.initSqlJs === 'function') {
+      initialise();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = `${SQL_JS_CDN_BASE}sql-wasm.js`;
+    script.async = true;
+    script.onload = initialise;
+    script.onerror = () => reject(new Error('Failed to load sql.js library.'));
+    document.head.appendChild(script);
   });
 
+  return sqlJsInstancePromise;
+}
+
+async function fetchDatabase(path) {
+  const response = await fetch(path, { cache: 'no-store' });
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} while fetching ${path}`);
   }
-
-  return response.text();
+  const buffer = await response.arrayBuffer();
+  return new Uint8Array(buffer);
 }
 
-function parseCSV(rawText) {
-  if (!rawText) return [];
+// Pull hearings and witnesses into JS objects for the UI to consume.
+function buildHearingsFromDatabase(db) {
+  const hearingRows = selectAll(
+    db,
+    `
+      SELECT id, chamber, source_hearing_id, event_id, url, title, date, time, datetime,
+             location, committee, tags, scraped_at, witness_list_pdf
+      FROM hearings
+      ORDER BY date, id
+    `,
+  );
 
-  let text = rawText;
-  if (text.charCodeAt(0) === 0xfeff) {
-    text = text.slice(1);
-  }
+  const witnessRows = selectAll(
+    db,
+    `
+      SELECT hearing_id, name, title, truth_in_testimony_pdf
+      FROM witnesses
+      ORDER BY hearing_id, id
+    `,
+  );
 
-  text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const hearings = hearingRows.map((row) => ({
+    id: Number(row.id),
+    chamber: (row.chamber || '').trim(),
+    sourceId: row.source_hearing_id ? String(row.source_hearing_id).trim() : null,
+    eventId: row.event_id !== null && row.event_id !== undefined ? Number(row.event_id) : null,
+    pageUrl: (row.url || '').trim(),
+    videoUrl: '',
+    title: (row.title || '').trim(),
+    date: row.date || '',
+    dateObj: parseIsoDate(row.date || ''),
+    time: row.time || '',
+    datetime: row.datetime || '',
+    location: (row.location || '').trim(),
+    committee: (row.committee || '').trim(),
+    tags: parseTagColumn(row.tags),
+    scrapedAt: row.scraped_at || '',
+    witnessListPdf: row.witness_list_pdf || '',
+    witnesses: [],
+    witnessDetails: [],
+    witnessKeys: [],
+  }));
 
+  attachWitnessesToHearings(hearings, witnessRows);
+  return hearings;
+}
+
+function selectAll(db, query) {
+  const stmt = db.prepare(query);
   const rows = [];
-  let currentCell = '';
-  let currentRow = [];
-  let withinQuotes = false;
-
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    const nextChar = text[index + 1];
-
-    if (char === '"') {
-      if (withinQuotes && nextChar === '"') {
-        currentCell += '"';
-        index += 1;
-      } else {
-        withinQuotes = !withinQuotes;
-      }
-      continue;
-    }
-
-    if (char === ',' && !withinQuotes) {
-      currentRow.push(currentCell);
-      currentCell = '';
-      continue;
-    }
-
-    if (char === '\n' && !withinQuotes) {
-      currentRow.push(currentCell);
-      rows.push(currentRow);
-      currentRow = [];
-      currentCell = '';
-      continue;
-    }
-
-    currentCell += char;
+  while (stmt.step()) {
+    rows.push(stmt.getAsObject());
   }
-
-  // Push the last cell if there's any residue.
-  if (currentCell.length > 0 || currentRow.length > 0) {
-    currentRow.push(currentCell);
-    rows.push(currentRow);
-  }
-
+  stmt.free();
   return rows;
 }
 
-function rowToHearing(row, columns) {
-  if (!row || row.every((cell) => cell.trim() === '')) {
-    return null;
-  }
-
-  const record = {};
-  columns.forEach((column, index) => {
-    record[column] = row[index] || '';
+function attachWitnessesToHearings(hearings, witnessRows) {
+  const hearingMap = new Map();
+  hearings.forEach((hearing) => {
+    hearingMap.set(hearing.id, hearing);
   });
 
-  const dateString = record.Date ? record.Date.trim() : '';
-  const parsedDate = parseDateString(dateString);
+  witnessRows.forEach((row) => {
+    const hearing = hearingMap.get(Number(row.hearing_id));
+    if (!hearing) return;
 
-  const witnesses = normalizeWitnesses(record.Witnesses || '');
-  const tags = Array.from(new Set(normalizeTags(record.Tags || '')));
+    const name = (row.name || '').trim();
+    if (!name) return;
 
-  return {
-    date: dateString,
-    dateObj: parsedDate,
-    title: (record.Title || '').trim(),
-    committee: (record.Committee || '').trim(),
-    pageUrl: (record.URL || '').trim(),
-    videoUrl: (record['Video Url'] || '').trim(),
-    tags,
-    witnesses,
-    witnessKeys: witnesses.map((name) => nameToKey(name)),
-  };
+    hearing.witnesses.push(name);
+    hearing.witnessDetails.push({
+      name,
+      title: (row.title || '').trim(),
+      truthInTestimonyPdf: row.truth_in_testimony_pdf || '',
+    });
+  });
+
+  hearings.forEach((hearing) => {
+    const seen = new Set();
+    const uniqueNames = [];
+    const uniqueDetails = [];
+
+    hearing.witnesses.forEach((name, index) => {
+      const key = nameToKey(name);
+      if (!key || seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      uniqueNames.push(name);
+      uniqueDetails.push(hearing.witnessDetails[index]);
+    });
+
+    hearing.witnesses = uniqueNames;
+    hearing.witnessDetails = uniqueDetails;
+    hearing.witnessKeys = uniqueNames.map((name) => nameToKey(name));
+  });
 }
 
-function parseDateString(value) {
-  if (!value) return null;
-  const parts = value.split('/');
-  if (parts.length < 3) return null;
-
-  const month = Number(parts[0]);
-  const day = Number(parts[1]);
-  let year = parts[2];
-
-  if (Number.isNaN(month) || Number.isNaN(day)) return null;
-
-  if (year.length === 2) {
-    const numeric = Number(year);
-    year = numeric >= 70 ? 1900 + numeric : 2000 + numeric;
-  } else {
-    year = Number(year);
-  }
-
-  if (!year || Number.isNaN(year)) return null;
-
-  return new Date(year, month - 1, day);
-}
-
-function normalizeWitnesses(raw) {
+function parseTagColumn(raw) {
   if (!raw) return [];
+  const text = String(raw).trim();
+  if (!text) return [];
 
-  return raw
-    .replace(/\u2022|\u25cf|\*/g, '\n')
-    .replace(/\r/g, '')
-    .split(/\n+/)
-    .flatMap((entry) => entry.split(/\s*;\s*/))
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-}
-
-function normalizeTags(raw) {
-  if (!raw) return [];
-  const cleaned = raw.replace(/\r|\n/g, '').trim();
-  if (!cleaned) return [];
-
-  const candidate = cleaned.replace(/""/g, '"');
-
+  const candidate = text.replace(/""/g, '"');
   try {
     const parsed = JSON.parse(candidate);
     if (Array.isArray(parsed)) {
       return parsed.map((tag) => String(tag).trim()).filter(Boolean);
     }
   } catch (error) {
-    // Fall back to manual parsing when JSON.parse fails.
+    // Fall through to fallback parsing.
   }
 
-  const fallback = candidate
+  return candidate
     .replace(/^\[/, '')
     .replace(/\]$/, '')
-    .replace(/[\"]/g, '');
-
-  return fallback
     .split(/,\s*/)
-    .map((tag) => tag.replace(/^'+|'+$/g, '').trim())
+    .map((tag) => tag.replace(/^['\"]+|['\"]+$/g, '').trim())
     .filter(Boolean);
+}
+
+function parseIsoDate(value) {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if ([year, month, day].some((part) => Number.isNaN(part))) {
+    return null;
+  }
+  return new Date(year, month - 1, day);
 }
 
 function buildWitnessMap(hearings) {
@@ -313,6 +372,7 @@ function buildWitnessMap(hearings) {
         name,
         hearings: [],
         count: 0,
+        chambers: new Set(),
       };
 
       if (!entry.name || entry.name.length < name.length) {
@@ -321,9 +381,16 @@ function buildWitnessMap(hearings) {
 
       entry.hearings.push(hearing);
       entry.count += 1;
+      if (hearing.chamber) {
+        entry.chambers.add(hearing.chamber);
+      }
 
       map.set(key, entry);
     });
+  });
+
+  map.forEach((entry) => {
+    entry.isDualChamber = entry.chambers.size >= 2;
   });
 
   return map;
@@ -375,9 +442,17 @@ function renderWitnessList() {
   }
 
   const query = state.filters.witnessQuery.toLowerCase();
-  const matching = state.sortedWitnesses.filter((witness) =>
-    !query || witness.name.toLowerCase().includes(query),
-  );
+  const dualOnly = state.filters.dualChamberOnly;
+  const matching = state.sortedWitnesses.filter((witness) => {
+    if (dualOnly && !witness.isDualChamber) {
+      return false;
+    }
+    return !query || witness.name.toLowerCase().includes(query);
+  });
+
+  if (state.selectedWitnessKey && !matching.some((w) => w.key === state.selectedWitnessKey)) {
+    state.selectedWitnessKey = null;
+  }
 
   if (!matching.length) {
     container.textContent = 'No witnesses match that search.';
@@ -454,7 +529,7 @@ function renderHearingsTable(hearings) {
   if (!hearings.length) {
     const row = document.createElement('tr');
     const cell = document.createElement('td');
-    cell.colSpan = 5;
+    cell.colSpan = 6;
     cell.className = 'empty-state';
     cell.textContent = 'No hearings match the current filters.';
     row.append(cell);
@@ -468,6 +543,10 @@ function renderHearingsTable(hearings) {
     const dateCell = document.createElement('td');
     dateCell.textContent = hearing.dateObj ? formatDate(hearing.dateObj) : hearing.date;
     row.append(dateCell);
+
+    const chamberCell = document.createElement('td');
+    chamberCell.textContent = formatChamber(hearing.chamber) || '—';
+    row.append(chamberCell);
 
     const titleCell = document.createElement('td');
     const titleLink = document.createElement('a');
@@ -590,11 +669,20 @@ function describeFilters() {
     parts.push(`through ${formatDate(endDate)}`);
   }
 
+  if (state.filters.dualChamberOnly) {
+    parts.push('dual-chamber witnesses only');
+  }
+
   if (!parts.length) {
     return '.';
   }
 
   return ` with ${parts.join(', ')}.`;
+}
+
+function formatChamber(chamber) {
+  if (!chamber) return '';
+  return chamber.charAt(0).toUpperCase() + chamber.slice(1);
 }
 
 function nameToKey(name) {
@@ -651,6 +739,8 @@ function compareByKey(key, a, b) {
       return compareDates(a.dateObj, b.dateObj);
     case 'title':
       return compareStrings(a.title, b.title);
+    case 'chamber':
+      return compareStrings(formatChamber(a.chamber), formatChamber(b.chamber));
     case 'committee':
       return compareStrings(a.committee, b.committee);
     case 'witnesses':
@@ -745,7 +835,7 @@ function showTableMessage(message) {
   tbody.innerHTML = '';
   const row = document.createElement('tr');
   const cell = document.createElement('td');
-  cell.colSpan = 5;
+  cell.colSpan = 6;
   cell.className = 'empty-state';
   cell.textContent = message;
   row.append(cell);

--- a/witnessWitness/combine_hearings.py
+++ b/witnessWitness/combine_hearings.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Merge House and Senate hearings databases into a unified schema."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+BASE_DIR = Path(__file__).resolve().parent
+HOUSE_DB = BASE_DIR / "hearings.db"
+SENATE_DB = BASE_DIR / "senate_hearings.sqlite"
+TARGET_DB = BASE_DIR / "hearings_combined.db"
+
+
+def normalize_date(raw: Optional[str]) -> Optional[str]:
+    """Convert incoming date strings to ISO format (YYYY-MM-DD) when possible."""
+    if not raw:
+        return None
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    # House data already uses ISO dates, so accept it as-is.
+    for fmt in ("%Y-%m-%d", "%m/%d/%y", "%m/%d/%Y"):
+        try:
+            return datetime.strptime(raw, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return raw  # Fall back to the original string if it is in an unknown format.
+
+
+def init_target_db(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA foreign_keys = ON;")
+    conn.executescript(
+        """
+        DROP TABLE IF EXISTS witnesses;
+        DROP TABLE IF EXISTS hearings;
+
+        CREATE TABLE hearings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chamber TEXT NOT NULL,
+            source_hearing_id TEXT,
+            event_id INTEGER,
+            url TEXT,
+            title TEXT,
+            date TEXT,
+            time TEXT,
+            datetime TEXT,
+            location TEXT,
+            committee TEXT,
+            tags TEXT,
+            scraped_at TEXT,
+            witness_list_pdf TEXT
+        );
+
+        CREATE TABLE witnesses (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            hearing_id INTEGER NOT NULL,
+            name TEXT,
+            title TEXT,
+            truth_in_testimony_pdf TEXT,
+            FOREIGN KEY (hearing_id) REFERENCES hearings(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX idx_hearings_chamber_source ON hearings(chamber, source_hearing_id);
+        CREATE INDEX idx_witnesses_hearing ON witnesses(hearing_id);
+        """
+    )
+    conn.commit()
+
+
+def merge_house_data(house_conn: sqlite3.Connection, target_conn: sqlite3.Connection) -> Dict[int, int]:
+    mapping: Dict[int, int] = {}
+    house_conn.row_factory = sqlite3.Row
+    cur = house_conn.cursor()
+
+    hearings = cur.execute(
+        """
+        SELECT id, url, event_id, title, date, time, datetime, location, scraped_at, witness_list_pdf
+        FROM hearings
+        ORDER BY id
+        """
+    ).fetchall()
+
+    insert_hearing = target_conn.execute
+    for row in hearings:
+        cursor = insert_hearing(
+            """
+            INSERT INTO hearings (
+                chamber, source_hearing_id, event_id, url, title, date, time, datetime,
+                location, committee, tags, scraped_at, witness_list_pdf
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "house",
+                str(row["event_id"]) if row["event_id"] is not None else None,
+                row["event_id"],
+                row["url"],
+                row["title"],
+                normalize_date(row["date"]),
+                row["time"],
+                row["datetime"],
+                row["location"],
+                None,
+                None,
+                row["scraped_at"],
+                row["witness_list_pdf"],
+            ),
+        )
+        mapping[row["id"]] = cursor.lastrowid
+
+    target_conn.commit()
+
+    witnesses = cur.execute(
+        """
+        SELECT hearing_id, name, title, truth_in_testimony_pdf
+        FROM witnesses
+        ORDER BY id
+        """
+    ).fetchall()
+
+    target_conn.executemany(
+        """
+        INSERT INTO witnesses (hearing_id, name, title, truth_in_testimony_pdf)
+        VALUES (?, ?, ?, ?)
+        """,
+        [
+            (
+                mapping[row["hearing_id"]],
+                row["name"],
+                row["title"],
+                row["truth_in_testimony_pdf"],
+            )
+            for row in witnesses
+        ],
+    )
+
+    target_conn.commit()
+    return mapping
+
+
+def merge_senate_data(senate_conn: sqlite3.Connection, target_conn: sqlite3.Connection) -> None:
+    senate_conn.row_factory = sqlite3.Row
+    cur = senate_conn.cursor()
+
+    hearings = cur.execute(
+        """
+        SELECT hearing_id, title, hearing_date, committee, tags
+        FROM hearings
+        ORDER BY hearing_id
+        """
+    ).fetchall()
+
+    insert_hearing = target_conn.execute
+    senate_id_map: Dict[int, int] = {}
+
+    for row in hearings:
+        cursor = insert_hearing(
+            """
+            INSERT INTO hearings (
+                chamber, source_hearing_id, event_id, url, title, date, time, datetime,
+                location, committee, tags, scraped_at, witness_list_pdf
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "senate",
+                str(row["hearing_id"]),
+                None,
+                None,
+                row["title"],
+                normalize_date(row["hearing_date"]),
+                None,
+                None,
+                None,
+                row["committee"],
+                row["tags"],
+                None,
+                None,
+            ),
+        )
+        senate_id_map[row["hearing_id"]] = cursor.lastrowid
+
+    target_conn.commit()
+
+    witness_rows = []
+    for hearing_id, combined_id in senate_id_map.items():
+        witnesses = cur.execute(
+            """
+            SELECT w.name
+            FROM hearing_witnesses hw
+            JOIN witnesses w ON w.witness_id = hw.witness_id
+            WHERE hw.hearing_id = ?
+            ORDER BY w.name
+            """,
+            (hearing_id,),
+        ).fetchall()
+        for witness in witnesses:
+            witness_rows.append((combined_id, witness["name"], None, None))
+
+    if witness_rows:
+        target_conn.executemany(
+            """
+            INSERT INTO witnesses (hearing_id, name, title, truth_in_testimony_pdf)
+            VALUES (?, ?, ?, ?)
+            """,
+            witness_rows,
+        )
+        target_conn.commit()
+
+
+def main() -> None:
+    if not HOUSE_DB.exists():
+        raise FileNotFoundError(f"House database not found at {HOUSE_DB}")
+    if not SENATE_DB.exists():
+        raise FileNotFoundError(f"Senate database not found at {SENATE_DB}")
+
+    if TARGET_DB.exists():
+        TARGET_DB.unlink()
+
+    with sqlite3.connect(HOUSE_DB) as house_conn, sqlite3.connect(SENATE_DB) as senate_conn, sqlite3.connect(TARGET_DB) as target_conn:
+        init_target_db(target_conn)
+        merge_house_data(house_conn, target_conn)
+        merge_senate_data(senate_conn, target_conn)
+
+
+if __name__ == "__main__":
+    main()

--- a/witnessWitness/index.html
+++ b/witnessWitness/index.html
@@ -72,6 +72,12 @@
                   </button>
                 </th>
                 <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="chamber">
+                    Chamber
+                    <span class="sort-indicator" aria-hidden="true"></span>
+                  </button>
+                </th>
+                <th scope="col">
                   <button type="button" class="sort-button" data-sort-key="title">
                     Title
                     <span class="sort-indicator" aria-hidden="true"></span>
@@ -103,9 +109,7 @@
       </section>
     </section>
   </main>
-  <footer class="page-footer">
-    <p>Tip: open this folder with a simple web server (<code>python -m http.server</code>) so the CSV can be fetched locally.</p>
-  </footer>
+  <footer class="page-footer"></footer>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a script to build a combined house + senate hearings database
- check in the generated database for quick use
- update the UI to load from the combined DB, expose chamber info, and add a dual-chamber witness filter

## Testing
-  in  and verified data renders with the new controls